### PR TITLE
Fix compilation with g++-6, Closes: #16 and automatically run test suite 

### DIFF
--- a/src/graph/hash_graph.h
+++ b/src/graph/hash_graph.h
@@ -188,8 +188,13 @@ public:
     void clear() { vertex_table_.clear(); num_edges_ = 0; }
 
 private:
+#if __cplusplus >= 201103L
+    HashGraph(const HashGraph &) = delete;
+    const HashGraph &operator =(const HashGraph &) = delete;
+#else
     HashGraph(const HashGraph &);
     const HashGraph &operator =(const HashGraph &);
+#endif
 
     bool GetNextVertexAdaptor(const HashGraphVertexAdaptor &current, HashGraphVertexAdaptor &next)
     {
@@ -428,7 +433,7 @@ inline std::ostream &operator <<(std::ostream &os, HashGraph &hash_graph)
 
 namespace std
 {
-template <> inline void swap(HashGraph &x, HashGraph &y)
+inline void swap(HashGraph &x, HashGraph &y)
 { x.swap(y); }
 }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -16,7 +16,7 @@ sequence_unittest_SOURCES = $(top_srcdir)/src/test/sequence_unittest.cpp
 short_sequence_unittest_SOURCES = $(top_srcdir)/src/test/short_sequence_unittest.cpp
 hash_map_unittest_SOURCES = $(top_srcdir)/src/test/hash_map_unittest.cpp 
 
-noinst_PROGRAMS = \
+check_PROGRAMS = \
 	compact_sequence_unittest \
 	hash_table_unittest \
 	bit_edges_unittest \
@@ -30,3 +30,4 @@ noinst_PROGRAMS = \
 	short_sequence_unittest \
 	hash_map_unittest 
 
+TESTS=$(check_PROGRAMS)


### PR DESCRIPTION
This pull request fixes two issues: 

* The patch against **src/graph/hash_graph.h** fixes compilation with g++-6 (in addition to the already applied changes to the ifstream handling) and really closes #16. 
* the patch against **test/Makefile.am** makes sure that the tests are only build when **make check** is called, and here the testa are also automatically run.  The latter is important for Debian packaging. 

Both patches were tested on Debian compiling with g++-5 and g++-6. 

Thanks for considering applying these patches. 

Best, 
Gert 