### PR TITLE
use a larger k

### DIFF
--- a/src/basic/kmer.h
+++ b/src/basic/kmer.h
@@ -197,7 +197,7 @@ public:
     { return kMaxSize; }
 
 
-    static const uint32_t kNumUint64 = 4;
+    static const uint32_t kNumUint64 = 10;
     static const uint32_t kBitsForSize = ((kNumUint64 <= 2) ? 6 : ((kNumUint64 <= 8) ? 8 : 16));
     static const uint32_t kBitsForKmer = (kNumUint64 * 64 - kBitsForSize);
     static const uint32_t kMaxSize = kBitsForKmer / 2;

--- a/src/sequence/short_sequence.h
+++ b/src/sequence/short_sequence.h
@@ -99,7 +99,7 @@ public:
         return size() < seq.size();
     }
 
-    static const uint32_t kMaxShortSequence = 128;
+    static const uint32_t kMaxShortSequence = 600;
     static const uint32_t kNumBytes = (kMaxShortSequence + 3) / 4 + 2;
 
 private:


### PR DESCRIPTION
one of our users patched idba_ud to be able to use up-to-date NGS techniques which generates longer short reads (300 in her case). Since the patch seems to work I was thinking it would be useful also for others. 