### PR TITLE
Add reference to bioconda installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ $ ./configure
 $ make
 ```
 
+### Install with bioconda
+To install with [bioconda](https://bioconda.github.io/), refer to: https://anaconda.org/bioconda/idba.
+
 
 ## Introduction
 


### PR DESCRIPTION
I first tried installing using the instructions on this page, but then realized there is also a bioconda option, so I thought it could be useful also for others if it was listed as an option here.